### PR TITLE
Make qa-tool runnable on github actions

### DIFF
--- a/.github/workflows/qa-tool-test.yml
+++ b/.github/workflows/qa-tool-test.yml
@@ -19,24 +19,76 @@ on:
         required: true
         default: 'stg'
       isSimpleReport:
-        description: 'simple report without details'
+        description: 'Simple report without details'
         required: true
-        default: 'false'
+        default: false
         type: boolean
+
+# Environment variables that are accessible for all jobs
+env:
+  REPO_OWNER: ${{ github.event.repository.owner.login }}
+  REPO_NAME: ${{ github.event.repository.name }}
+
+  # The path to the file where the report will be saved
+  # after the completion of the QA-tool
+  REPORT_FILE_PATH: pr-report.md
 
 jobs:
   qa-tool:
     runs-on: ubuntu-latest
-    # will add later
-    # permissions:
-    #   contents: read
+
+    # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token#defining-access-for-the-github_token-permissions
+    permissions:
+      # following two permissions are required to read the contents of the repository
+      pull-requests: read
+      contents: read
+
     steps:
-      - name: logs
+
+      # # Debugging: uncomment the following lines to see the logs
+      # - name: Logs
+      #   run: |
+      #     echo "event: ${{ toJson(github.event) }}"
+      #     echo "Command: ${{ github.event.inputs.command }}"
+      #     echo "Source branch: ${{ github.event.inputs.sourceBranch }}"
+      #     echo "Target branch: ${{ github.event.inputs.targetBranch }}"
+      #     echo "isSimpleReport: ${{ github.event.inputs.isSimpleReport }}"
+      #     echo "Secret: ${{ toJson(secrets) }}"
+      #     echo "Environment: ${{ toJson(env) }}"
+      #     echo "Runner: ${{ toJson(runner) }}"
+      #     ls -la
+      #     pwd
+
+      # Checkout the repository: need to access the repository
+      - name: 'deps: Checkout install'
+        uses: actions/checkout@v4
+
+      - name: Node.js setup
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run QA-tool & make a report
+        env:
+          # The GITHUB_TOKEN is required to access the pull requests
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
         run: |
-          echo "Running QA-tool"
-          echo "event: ${{ github.event }}"
-          echo "Command: ${{ github.event.inputs.command }}"
-          echo "Source branch: ${{ github.event.inputs.sourceBranch }}"
-          echo "Target branch: ${{ github.event.inputs.targetBranch }}"
-          echo "isSimpleReport: ${{ github.event.inputs.isSimpleReport }}"
-          echo "secret: ${{ secrets }}"
+          touch ${{ env.REPORT_FILE_PATH }}
+          npx tsx qa-tool.ts \
+            ${{ github.event.inputs.command }} \
+            ${{ github.event.inputs.sourceBranch }} \
+            ${{ github.event.inputs.targetBranch }} \
+            --path ${{ env.REPORT_FILE_PATH }} \
+            ${{ github.event.inputs.isSimpleReport == 'true' && '--simple' || '' }}
+
+      # Upload the file as an artifact to make it downloadable
+      - name: Report upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-report
+          # The path to the file where the report is saved
+          path: ${{ runner.workspace }}/${{ env.REPO_NAME }}/${{ env.REPORT_FILE_PATH }}

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Create a `.env` file in your project's root with:
 REPO_OWNER=your-repo-owner
 REPO_NAME=your-repo-name
 GITHUB_TOKEN=your-github-token
-GIT_ROOT_DIR=your-git-root-dir
+GIT_ROOT_DIR=your-git-root-dir (optional: default is the root of the repository)
 ```
 
 ## Commands

--- a/commands/branch.ts
+++ b/commands/branch.ts
@@ -33,6 +33,18 @@ type Commit = { hash: string, message: string };
  * ```
  */
 async function listCommitsNotInBranch(sourceBranch: string, targetBranch: string): Promise<Commit[]> {
+  /*
+    Fetch the latest commits from the remote repository
+    to ensure the local repository is up-to-date.
+    This is necessary to get the latest commits from the remote repository
+    and avoid missing any commits in the local repository.
+  */
+  await execAsync(`git fetch origin ${sourceBranch} ${targetBranch}`);
+  await execAsync(`git switch ${sourceBranch}`);
+  await execAsync(`git pull origin ${sourceBranch}`);
+  await execAsync(`git switch ${targetBranch}`);
+  await execAsync(`git pull origin ${targetBranch}`);
+
   const cmd = `git log --oneline ${targetBranch}..${sourceBranch}`;
   const { stdout } = await execAsync(cmd);
 

--- a/utils/misc.ts
+++ b/utils/misc.ts
@@ -60,11 +60,12 @@ export const extractPRDetails = (prTemplate: string) => {
 
 /**
  * Function to write content to a file.
+ * Creates the file if it does not exist.
  * @returns true if the file was written successfully, false otherwise
  */
 export const writeOnFile = async (path: string, content: string): Promise<boolean> => { 
   try {
-    await fsp.writeFile(path, content, 'utf8');
+    await fsp.writeFile(path, content, { flag: 'w', encoding: 'utf8' });
     return true;
   } catch (error) {
     console.error('Failed to write file:', error);


### PR DESCRIPTION
- [x] Specify tickets that should be closed when merged:
Closes none

- Specify PRs that need to be:
  - [x] deployed before this one: none
  - [x] merged before this one: none

<!-- Do not remove the comments. Those are useful for data extraction. e.g: qa-tool -->
## <!-- type -->Specify which kind of change this PR introduces (keep applicable)

- [x] New feature

## <!-- changelog -->How would you describe the changes in the customer visible changelog (1-2 lines)?
- no user visible changes

## What was done
- Make qa-tool runnable on github actions
- Additional bugfixes

## How it was and should be tested

Approved PRs that have no QA_needed label are considered production ready with no further testing by QA.

- [x] regression testing is not needed.

## REST API

- [x] REST API Documentation has been update or is not needed.

## Risks

Please assess risk & follow up on deployment of this PR.

<!-- risk -->
- [x] Risk assessment: (remove not relevant and add notes)
 * Non-trivial changes

## Reviewer Notes

- [x] Approved and tested according to link

## <!-- follow_up -->Deploy follow up

- [x] Follow up deploy tasks: none

## QA - if regression testing was requested:

- [x] no QA_needed label was present
